### PR TITLE
empty message fix

### DIFF
--- a/server.go
+++ b/server.go
@@ -166,7 +166,7 @@ func (s *Server) receiver(c net.Conn) {
 
         // Parse msg part
         msg := string(bytes.TrimRightFunc(pkt, isNulCrLf))
-        if msg[0] != ' ' {
+        if strings.HasPrefix(msg, " ") {
             msg = " " + msg
         }
         n = strings.IndexFunc(msg, isNotAlnum)


### PR DESCRIPTION
If message is empty, there will be index out of range error
```
panic: runtime error: index out of range

goroutine 34 [running]:
gitlab.beget.ru/golang/svc-php-block-logger/vendor/github.com/bmconklin/syslog.(*Server).receiver(0xc420164320, 0xe03aa0, 0xc42016a0c0)
	/go/src/gitlab.beget.ru/golang/svc-php-block-logger/vendor/github.com/bmconklin/syslog/server.go:169 +0x675
created by gitlab.beget.ru/golang/svc-php-block-logger/vendor/github.com/bmconklin/syslog.(*Server).Listen
	/go/src/gitlab.beget.ru/golang/svc-php-block-logger/vendor/github.com/bmconklin/syslog/server.go:81 +0x127
```